### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@ Data Science (for Social Good) 101
 
 Resources and learning modules covering methods, tools, tips, and tricks for anyone interested in getting started doing data science for the social good.
 
-###What's Here
+### What's Here
 
 - Introductions to key concepts (markdown files)
 - Resource lists (markdown files)
 - Learning Modules (folders)
 
 
-###Directories
+### Directories
 
 - Methods
 - Tools
 - Projects
   
-###How to Contribute
+### How to Contribute
 
 - If you're a DSSG member, commit away
 - If you would like to contribute materials, ask to be added to the organization or submit a pull request

--- a/Tools/Python/Python_for_data_analysis.md
+++ b/Tools/Python/Python_for_data_analysis.md
@@ -1,13 +1,13 @@
 
-#Python for Data Analysis: Lighting the Python Spark with a Little Energy Data
+# Python for Data Analysis: Lighting the Python Spark with a Little Energy Data
 
-##Background
+## Background
 
-###What is Python?
+### What is Python?
 
 [Python](https://www.python.org/) is a dynamically typed interpreted language with a fantastic and active user community, [distinctive culture](http://blog.startifact.com/posts/older/what-is-pythonic.html), and [loads of online resources.](https://wiki.python.org/moin/BeginnersGuide/Programmers)
 
-###Why Python for Data Science?
+### Why Python for Data Science?
 
 As a general-purpose, high-level programming language, Python is a great language for getting just about anything you need to get done done. It has a simple, intuitive syntax that makes python programs easy to write and easy to understand.
 
@@ -19,7 +19,7 @@ There are lots of great places to learn data analysis in python. Take a look at 
 
 Okay, let's get started.
 
-###Setup
+### Setup
 
 For this tutorial, you'll need to install ipython, numpy, scipy, pandas, and sklearn.
 
@@ -29,7 +29,7 @@ If you already have python installed, installing new python libraries is as easy
 
 try `pip install pandas`
 
-###The basics: 
+### The basics: 
 Python is an interpreted language, which means your computer runs a program that interprets the code that you writes converts it into. Let's try it out.
 
 `>>> print "Hello DSSG!"`
@@ -43,12 +43,12 @@ Python is an interpreted language, which means your computer runs a program that
 `import this`
 
 
-###Making Python Interactive
+### Making Python Interactive
 That's great, but what if I'm lazy and want things like tab completion.
 
 [IPython](http://ipython.org/) is a great tool created by friend of DSSG, Fernando Perez.  
 
-###Making Python Interactive, Literate, and Beautiful
+### Making Python Interactive, Literate, and Beautiful
 
 The terminal is powerful but ugly. The browser is beautiful but limited. If only we could combine the power of the terminal with the beauty of the browser. 
 
@@ -56,16 +56,16 @@ We can! Thanks to IPython Notebook.
 
 `ipython notebook --pylab=inline`
 
-####IPython Notebook is great
+#### IPython Notebook is great
 
 To show you the power of iPython Notebook,I'm going to follow  
 
-###Getting Started with Some Data Structures: Lists, Dictionaries, Arrays, Matricies, Series, and DataFrames
+### Getting Started with Some Data Structures: Lists, Dictionaries, Arrays, Matricies, Series, and DataFrames
 
 There are lots of great ways. In fact, one of the ways that people are pythonic are by smartly using data structures like tuples, lists, and dictionarys. Let's explore python data structures. You can follow along using the data structures notebook.
 
 
-###Fun with Baby Names
+### Fun with Baby Names
 
 Go [here](http://www.babynamewizard.com/baby-name) to find out the peak year of the popularity of your name.
 
@@ -74,20 +74,20 @@ Now go [here](https://docs.google.com/spreadsheets/d/1HJxGgy-yUUe59IZRxBogw1Hvf8
 Lastly, go [here](http://www.ssa.gov/oact/babynames/limits.html) to download the names database.
 
 
-###Working with Data: Energy Use by Participants in the Chicago Neighborhood Energy Challenge
+### Working with Data: Energy Use by Participants in the Chicago Neighborhood Energy Challenge
 
 
 
 statsmodels uses [patsy](http://patsy.readthedocs.org/en/latest/), which is a great library for describing statistical models in python
 
 
-###Statsmodels: a great statistical library
+### Statsmodels: a great statistical library
 Patsy is smart and automatically treats strings as categorical variables. You can make categorical variables explicit by using 
 
 Using Formulas
 
 Statsmodels typically 
 
-####Bonus featurs for IPython Notebook
+#### Bonus featurs for IPython Notebook
 
 - IPython 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
